### PR TITLE
Defining the logging_in callback when the controller loads

### DIFF
--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -4,21 +4,10 @@ module DeviseGuests::Controllers
 
     included do
       include ActiveSupport::Callbacks
-      (DeviseGuests::Controllers::Helpers.callbacks || []).each do |c|
-        define_callbacks *c
-      end
-
     end
-
-    mattr_reader :callbacks
 
     module ClassMethods
 
-    end
-
-    def self.define_concern_callbacks *args
-      @@callbacks ||= []
-      @@callbacks << args
     end
 
     def self.define_helpers(mapping) #:nodoc:
@@ -26,9 +15,7 @@ module DeviseGuests::Controllers
       mapping = mapping.name
 
       class_eval <<-METHODS, __FILE__, __LINE__ + 1
-        define_concern_callbacks :logging_in_#{mapping}
 
- 
         def guest_#{mapping}
           return @guest_#{mapping} if @guest_#{mapping}
 
@@ -89,6 +76,7 @@ module DeviseGuests::Controllers
 
       ActiveSupport.on_load(:action_controller) do
         helper_method "guest_#{mapping}", "current_or_guest_#{mapping}"
+        define_callbacks "logging_in_#{mapping}"
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -24,4 +24,25 @@ describe ApplicationController, :type => :controller do
     expect(@controller.current_or_guest_user).to eq(m)
   end
 
+  it "should run the 'logging_in' callbacks" do
+
+    # A user is logged in
+    current_user = double()
+    allow(@controller).to receive(:current_user) { current_user }
+
+    # There is a guest user instance
+    guest_user = double()
+    allow(guest_user).to receive(:destroy)
+    allow(@controller).to receive(:guest_user) { guest_user }
+    allow(@controller).to receive(:session) { { guest_user_id: 123 } }
+
+    expect(@controller).to receive(:run_callbacks).with(:logging_in_user).and_call_original
+
+    @controller.current_or_guest_user
+  end
+
+  it "should define a 'logging_in' callback" do
+    expect(@controller.respond_to? :_logging_in_user_callbacks).to be true
+  end
+
 end


### PR DESCRIPTION
From what I've been able to tell, the include block (where the callbacks were being defined) was always being run before define_concern_callbacks, and so DeviseGuests::Controllers::Helpers.callbacks was always nil and no callbacks were being defined.

Defining the callback when the controller loads seems to fix all of the issues I've been having with the callbacks not being defined.

Do we need to define_callbacks whenever the module is included, or will it be OK to just define them on_load ?
