### PR TITLE
Fix Devise.authentication_keys method name

### DIFF
--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -71,7 +71,7 @@ module DeviseGuests::Controllers
           end
         end
 
-        def guest_email_authentication_key key
+        def guest_#{class_name.constantize.authentication_keys.first}_authentication_key key
           key &&= nil unless key.to_s.match(/^guest/)
           key ||= "guest_" + guest_#{mapping}_unique_suffix + "@example.com"
         end


### PR DESCRIPTION
If you have in your Devise configuration changed authentication_keys like:
```ruby
 config.authentication_keys = [:phone]
```
In project was hardcoded generation method guest_email_authentication_key
But we need to be dynamic from config.authentication_keys
In this fix takes only first element of array