### PR TITLE
avoid cross process conflicts in guest users

### DIFF
--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -28,13 +28,13 @@ module DeviseGuests::Controllers
       class_eval <<-METHODS, __FILE__, __LINE__ + 1
         define_concern_callbacks :logging_in_#{mapping}
 
- 
+
         def guest_#{mapping}
           return @guest_#{mapping} if @guest_#{mapping}
 
           if session[:guest_#{mapping}_id]
             @guest_#{mapping} = #{class_name}.find_by(#{class_name}.authentication_keys.first => session[:guest_#{mapping}_id]) rescue nil
-            @guest_#{mapping} = nil if @guest_#{mapping}.respond_to? :guest and !@guest_#{mapping}.guest 
+            @guest_#{mapping} = nil if @guest_#{mapping}.respond_to? :guest and !@guest_#{mapping}.guest
           end
 
           @guest_#{mapping} ||= begin
@@ -77,12 +77,7 @@ module DeviseGuests::Controllers
         end
 
         def guest_#{mapping}_unique_suffix
-          Devise.friendly_token + "_" + Time.now.to_i.to_s + "_" + unique_#{mapping}_counter.to_s
-        end
-
-        def unique_#{mapping}_counter
-          @@unique_#{mapping}_counter ||= 0
-          @@unique_#{mapping}_counter += 1
+          SecureRandom.uuid
         end
 
       METHODS


### PR DESCRIPTION
By using uuid instead of time based id

We're seeing unique constraint violations in the production, and traced this to the existing counter is not being safe across processes. It didn't look the like time component was essential here, so we're suggesting that a UUID be subbed in.