### PR TITLE
Allow setting of custom params on guest model

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,40 @@ guest_user # ( for anonymous users)
 => User<id: nil, email: guest_RANDOMENOUGHSTRING_@example.com, guest: true>
 
 ```
+
+### Transferring Guest to User on Login
+
+During the login process you may want to transfer things from your guest user to the account the logged into.
+To do so, modify your ApplicationController like so:
+
+```ruby
+define_callbacks :logging_in_user
+set_callback :logging_in_user, :before, :transfer_guest_to_current_user
+
+private
+def transfer_guest_to_current_user
+  # At this point you have access to:
+  #   * current_user - the user they've just logged in as
+  #   * guest_user - the guest user they were previously identified by
+  # 
+  # After this block runs, the guest_user will be destroyed!
+  
+  if current_user.cart
+    guest_user.cart.line_items.update_all(cart_id: current_user.cart.id)
+  else
+    guest_user.cart.update!(user: current_user)
+  end
+end
+```
+
+### Custom attribute
+
+If you have added additional authentication_keys, or have other attributes on your Devise model that you need to set
+when creating a guest user, you can do so by overriding the set_guest_user_params method in your ApplicationController:
+
+```ruby
+private
+def guest_user_params
+  { site_id: current_site.id }
+end
+```

--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -65,6 +65,7 @@ module DeviseGuests::Controllers
           auth_key = #{class_name}.authentication_keys.first
           #{class_name}.new do |g|
             g.send("\#{auth_key}=", send(:"guest_\#{auth_key}_authentication_key", key))
+            g.assign_attributes(send(:"guest_#{mapping}_params"))
             g.guest = true if g.respond_to? :guest
             g.skip_confirmation! if g.respond_to?(:skip_confirmation!)
             g.save(validate: false)
@@ -74,6 +75,10 @@ module DeviseGuests::Controllers
         def guest_email_authentication_key key
           key &&= nil unless key.to_s.match(/^guest/)
           key ||= "guest_" + guest_#{mapping}_unique_suffix + "@example.com"
+        end
+
+        def guest_#{mapping}_params
+          {}
         end
 
         def guest_#{mapping}_unique_suffix


### PR DESCRIPTION
This enables the setting of custom parameters on the devise guest model when creating the guest account instance. By overriding the set_guest_MAPPING_params method you are able to return a new hash of params that should be assigned to the new guest created.

This PR is a replacement for #30, since that was created off `pacso:master` and prevented me from creating additional PRs.