### PR TITLE
Update helpers to search for users unscoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2021-12-22
+### Changed
+- Support for default scopes where guests are hidden ([#41](https://github.com/cbeer/devise-guests/pull/41))
+
 ## [0.8.1] - 2021-10-26
 ### Changed
 - Simplify guest transfer ([#38](https://github.com/cbeer/devise-guests/pull/38))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.2] - 2021-12-22
+## [Unreleased]
 ### Changed
 - Support for default scopes where guests are hidden ([#41](https://github.com/cbeer/devise-guests/pull/41))
 

--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -18,7 +18,7 @@ module DeviseGuests::Controllers
           return @guest_#{mapping} if @guest_#{mapping}
 
           if session[:guest_#{mapping}_id]
-            @guest_#{mapping} = #{class_name}.find_by(#{class_name}.authentication_keys.first => session[:guest_#{mapping}_id]) rescue nil
+            @guest_#{mapping} = #{class_name}.unscoped.find_by(#{class_name}.authentication_keys.first => session[:guest_#{mapping}_id]) rescue nil
             @guest_#{mapping} = nil if @guest_#{mapping}.respond_to? :guest and !@guest_#{mapping}.guest
           end
 

--- a/lib/devise-guests/version.rb
+++ b/lib/devise-guests/version.rb
@@ -1,3 +1,3 @@
 module DeviseGuests
-  VERSION = "0.8.2"
+  VERSION = "0.8.1"
 end

--- a/lib/devise-guests/version.rb
+++ b/lib/devise-guests/version.rb
@@ -1,3 +1,3 @@
 module DeviseGuests
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/lib/railties/devise_guests.rake
+++ b/lib/railties/devise_guests.rake
@@ -6,6 +6,6 @@ namespace :devise_guests do
   desc "Removes entries in the users table for guest users that are older than the number of days given."
   task :delete_old_guest_users, [:days_old] => [:environment] do |t, args|
     args.with_defaults(days_old: 7)
-    User.where("guest = ? and updated_at < ?", true, Time.now - args[:days_old].to_i.days).each { |x| x.destroy }
+    User.unscoped.where("guest = ? and updated_at < ?", true, Time.now - args[:days_old].to_i.days).each { |x| x.destroy }
   end
 end


### PR DESCRIPTION
This is to fix error where `User.find_by` fails to find existing guest users when the app has `User.default_scope` set to `where( guest:false )`

many hyku/hyrax/spotlight/blacklight apps have this setting and it causes errors to crop up when the `guest_user` method is called so logged in users will never see this error.