### PR TITLE
Use find_each in delete_old_guest_users task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.2] - 2022-01-20
+## [Unreleased]
 ### Fixed
 - Prevent crashing processes due to loading all guest users in memory during delete_old_guest_users task ([#42](https://github.com/cbeer/devise-guests/pull/42))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2022-01-20
+### Fixed
+- Prevent crashing processes due to loading all guest users in memory during delete_old_guest_users task ([#42](https://github.com/cbeer/devise-guests/pull/42))
+
 ## [0.8.1] - 2021-10-26
 ### Changed
 - Simplify guest transfer ([#38](https://github.com/cbeer/devise-guests/pull/38))

--- a/lib/railties/devise_guests.rake
+++ b/lib/railties/devise_guests.rake
@@ -4,8 +4,10 @@ namespace :devise_guests do
   # example cron entry to delete users older than 7 days at 2:00 AM every day:
   # 0 2 * * * cd /path/to/your/app && /path/to/rake devise_guests:delete_old_guest_users[7] RAILS_ENV=your_env
   desc "Removes entries in the users table for guest users that are older than the number of days given."
-  task :delete_old_guest_users, [:days_old] => [:environment] do |t, args|
-    args.with_defaults(days_old: 7)
-    User.where("guest = ? and updated_at < ?", true, Time.now - args[:days_old].to_i.days).each { |x| x.destroy }
+  task :delete_old_guest_users, [:days_old, :batch_size] => [:environment] do |t, args|
+    args.with_defaults(days_old: 7, batch_size: 1000)
+    User
+      .where("guest = ? and updated_at < ?", true, Time.now - args[:days_old].to_i.days)
+      .find_each(batch_size: batch_size, &:destroy)
   end
 end


### PR DESCRIPTION
closes #43 

If there are a lot of guest users the process can crash without
deleting anything.
This change ensures all guest users are not loaded into memory.
Provide a default batch size of 25,000.

This is similar to the override we're running in orangelight: https://github.com/pulibrary/orangelight/blob/00eda23b5e2977567e938fc65eb1dd969bfffb3e/app/models/user.rb#L59-L63