### PR TITLE
Fix race condition with multi-thread servers with guest accounts when logging into existing account

### DIFF
--- a/devise-guests.gemspec
+++ b/devise-guests.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_dependency "devise"
+  s.add_dependency "with_advisory_lock", "~> 4.6"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rake"

--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -35,7 +35,9 @@ module DeviseGuests::Controllers
           if current_#{mapping}
             if session[:guest_#{mapping}_id]
               run_callbacks :logging_in_#{mapping} do
-                guest_#{mapping}.destroy unless send(:"skip_destroy_guest_#{mapping}")
+                #{class_name}.with_advisory_lock(current_#{mapping}.email) do
+                  guest_#{mapping}.destroy unless send(:"skip_destroy_guest_#{mapping}")
+                end
                 session[:guest_#{mapping}_id] = nil
               end
             end

--- a/lib/devise-guests/controllers/helpers.rb
+++ b/lib/devise-guests/controllers/helpers.rb
@@ -53,7 +53,9 @@ module DeviseGuests::Controllers
             g.assign_attributes(send(:"guest_#{mapping}_params"))
             g.guest = true if g.respond_to? :guest
             g.skip_confirmation! if g.respond_to?(:skip_confirmation!)
-            g.save(validate: false)
+            #{class_name}.with_advisory_lock(g.email) do
+              g.save(validate: false)
+            end
           end
         end
 


### PR DESCRIPTION
When logging into an existing account from a guest account on a multi-thread server (like Puma) `devise-guests` enters a race condition where some threads believe the guest user exists and some threads believe the guest user has been deleted and then tries to create it again. This leads to an effectively meaningless error that the guest user's email is already taken in the database as the non-guest account is logged in. This solution adds a dependency for `with_advisory_lock` but it prevents the unnecessary error.

We should probably also make sure this doesn't "undelete" deleted guest account on successful login.