### PR TITLE
Update README to include note on reloading guest_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ def transfer_guest_to_user
     guest_user.cart.update!(user: current_user)
   end
 
-  # Note: you may want to call `guest_user.reload` at the end of this
-  # function to ensure any dependent hooks (destroy, nullify, etc)
-  # are not run from the guest_user's outdated associations
+  # In this example we've moved `LineItem` records from the guest
+  # user's cart to the logged-in user's cart.
+  #
+  # To prevent these being deleted when the guest user & cart are
+  # destroyed, we need to reload the guest record:
+  guest_user.reload
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ guest_user # ( for anonymous users)
 
 ### Transferring Guest to User on Login
 
-During the login process you may want to transfer things from your guest user to the account the logged into.
+During the login process you may want to transfer things from your guest user to the account they logged into.
 To do so, add the following method to your ApplicationController:
 
 ```ruby
@@ -58,6 +58,10 @@ def transfer_guest_to_user
   else
     guest_user.cart.update!(user: current_user)
   end
+
+  # Note: you may want to call `guest_user.reload` at the end of this
+  # function to ensure any dependent hooks (destroy, nullify, etc)
+  # are not run from the guest_user's outdated associations
 end
 ```
 


### PR DESCRIPTION
In the scenario where a `User` record has a `dependent: :destroy` association, such as
```rb
class User < ApplicationRecord
  devise :database_authenticatable # etc

  has_many :tasks, dependent: :destroy
end
```

When you implement `transfer_guest_to_user` like this
```rb
class ApplicationController < ActionController::Base
  private

  def transfer_guest_to_user
    guest_user.tasks.update!(user: current_user)
  end
end
```

You run into the problem where the dependent `tasks` are still destroyed when the `guest_user` is destroyed. 
```sql
TRANSACTION (0.8ms)  BEGIN
Task Destroy (0.8ms)  DELETE FROM "tasks" WHERE "tasks"."id" = $1  [["id", "1d1b92dc-f951-4ec0-8637-b5b96a3a2087"]]
# guest_user id
User Destroy (0.7ms)  DELETE FROM "users" WHERE "users"."id" = $1  [["id", "0902f0d5-3f47-4eb7-8a7b-5539833b7ccd"]]
TRANSACTION (1.0ms)  COMMIT
```

Because the `guest_user` in memory that is being destroyed still references the `task`. This can be solved with a simple `reload` before destroying the guest_user to make sure that the in-memory record is up to date.

I confirmed that this fix works in my Rails app, but I noticed we use `double` for mocking in the specs and it wouldn't feel great to just mock all the functionality to test this use case. If you'd like me to set up a factory and persist some records to the Database to write a test for this I'd be happy to, just let me know.